### PR TITLE
Когда размер величины, выводимой на экран с помощью манипулятора

### DIFF
--- a/Глава 2/8()/main.cpp
+++ b/Глава 2/8()/main.cpp
@@ -1,0 +1,9 @@
+﻿#include <iostream>
+#include <iomanip>
+
+int main()
+{
+	long pop1 = 8425785, pop2 = 47, pop3 = 9761;
+	std::cout << std::setw(9) << "Moscow" << std::setfill('.') << std::setw(12) << pop1 << std::endl
+		<< std::setfill(' ') << std::setw(9) << "Saint" << std::setfill('.') << std::setw(12) << pop2;
+}


### PR DESCRIPTION
setw(), оказывается меньше размера зарезервированного поля, по умолчанию незаполненные поля заполняются пробелами. Манипулятор setfill()
принимает в качестве аргумента один символ, который замещает все пробелы на незаполненных позициях поля. Модифицируйте пример WIDTH
так, чтобы символы, разделяющие пары значений из столбцов, были не
пробелами, а точками, напримеp